### PR TITLE
Change drafted move Job Type

### DIFF
--- a/1.6/Source/PokeWorld/FloatMenuOptionProvider/FloatMenuOptionProvider_PokemonDraftedMove.cs
+++ b/1.6/Source/PokeWorld/FloatMenuOptionProvider/FloatMenuOptionProvider_PokemonDraftedMove.cs
@@ -107,18 +107,18 @@ internal class FloatMenuOptionProvider_PokemonDraftedMove : FloatMenuOptionProvi
         if (pawn.Position == gotoLoc)
         {
             flag = true;
-            if (pawn.CurJobDef == JobDefOf.Goto)
+            if (pawn.CurJobDef == DefDatabase<JobDef>.GetNamed("PW_PokemonGotoForced"))
             {
                 pawn.jobs.EndCurrentJob(JobCondition.Succeeded);
             }
         }
-        else if (pawn.CurJobDef == JobDefOf.Goto && pawn.CurJob.targetA.Cell == gotoLoc)
+        else if (pawn.CurJobDef == DefDatabase<JobDef>.GetNamed("PW_PokemonGotoForced") && pawn.CurJob.targetA.Cell == gotoLoc)
         {
             flag = true;
         }
         else
         {
-            Job job = JobMaker.MakeJob(JobDefOf.Goto, gotoLoc);
+            Job job = JobMaker.MakeJob(DefDatabase<JobDef>.GetNamed("PW_PokemonGotoForced"), gotoLoc);
             if (pawn.Map.exitMapGrid.IsExitCell(clickCell))
             {
                 job.exitMapOnArrival = !pawn.IsColonyMech;


### PR DESCRIPTION
The JobDriver_PokemonGotoForced has an idle action of watching for targets. The basic Goto action idles with following which just means the pokemon moves and immediately moves back.
This was the behavior in 1.5.